### PR TITLE
Fix for when you pass a non-object

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,9 @@ var ERROR_TYPE = '[object Error]';
 module.exports = isError;
 
 function isError(err) {
+    if (typeof err !== 'object') {
+        return false;
+    }
     while (err) {
         if (objectToString.call(err) === ERROR_TYPE) {
             return true;

--- a/test/index.js
+++ b/test/index.js
@@ -20,6 +20,10 @@ test('returns false for non-error', function t(assert) {
     assert.equal(isError(null), false);
     assert.equal(isError(undefined), false);
     assert.equal(isError({message: 'hi'}), false);
+    assert.equal(isError(true), false);
+    assert.equal(isError(false), false);
+    assert.equal(isError(1), false);
+    assert.equal(isError('string'), false);
     assert.end();
 });
 


### PR DESCRIPTION
Passing a boolean, string or number causes a hard error.  This make sure that you can pass these non-error types and get the correct behavior.
